### PR TITLE
cd27a58 - GSC Schema fixes

### DIFF
--- a/templates/components/common/responsive-img.html
+++ b/templates/components/common/responsive-img.html
@@ -36,7 +36,7 @@ There are a few important arguments to know about when using this component:
 
 --}}
 <img {{#if image}}{{!-- Get the default image for legacy browsers that do not support srcset
---}}src="{{getImageSrcset image 1x=(default fallback_size '160w')}}" alt="{{image.alt}}" title="{{image.alt}}" {{!--
+--}}itemprop="image" src="{{getImageSrcset image 1x=(default fallback_size '160w')}}" alt="{{image.alt}}" title="{{image.alt}}" {{!--
   Allow lazysizes to generate the 'sizes' attribute automatically --}}data-sizes="auto"
   {{#unless lazyload '==' 'disabled'}}
     {{#if lazyload '==' 'lazyload+lqip'}}

--- a/templates/components/products/price.html
+++ b/templates/components/products/price.html
@@ -9,6 +9,8 @@ If you are making a change here or in price-range.html, you probably want to mak
 {{else}}
     {{#if price.with_tax}}
         <div class="price-section price-section--withTax" {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+            <!-- Google needs price here to validate price schema -->
+            <meta itemprop="price" content="{{price.with_tax.value}}">
             <span class="price-section price-section--withTax non-sale-price--withTax" {{#unless price.non_sale_price_with_tax}}style="display: none;"{{/unless}}>
                 <span data-product-non-sale-price-with-tax class="price price--non-sale">
                     {{price.non_sale_price_with_tax.formatted}}
@@ -21,7 +23,9 @@ If you are making a change here or in price-range.html, you probably want to mak
             {{#if schema_org}}
                 <meta itemprop="availability" itemtype="https://schema.org/ItemAvailability"
                 	content="https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
-                <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition">
+                <!-- <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition"> -->
+                <!-- Hard coding condition. Always selling products in new condition -->
+                <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/NewCondition">
                 <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
                 <meta itemprop="url" content="{{product.url}}">
                 <div itemprop="priceSpecification" itemscope itemtype="https://schema.org/PriceSpecification">
@@ -37,6 +41,8 @@ If you are making a change here or in price-range.html, you probably want to mak
     {{/if}}
     {{#if price.without_tax}}
         <div class="price-section price-section--withoutTax {{#if price.with_tax}}price-section--minor{{/if}}"  {{#if schema_org}}itemprop="offers" itemscope itemtype="http://schema.org/Offer"{{/if}}>
+            <!-- Google needs price here to validate price schema -->
+            <meta itemprop="price" content="{{price.without_tax.value}}">
             <span class="price-section price-section--withoutTax non-sale-price--withoutTax{{#if price.with_tax}} price-section--minor{{/if}}" {{#unless price.non_sale_price_without_tax}}style="display: none;"{{/unless}}>
                 <span data-product-non-sale-price-without-tax class="price price--non-sale">
                     {{price.non_sale_price_without_tax.formatted}}
@@ -49,7 +55,9 @@ If you are making a change here or in price-range.html, you probably want to mak
             {{#if schema_org}}
                 <meta itemprop="availability" itemtype="https://schema.org/ItemAvailability"
                     content="https://schema.org/{{#if product.pre_order}}PreOrder{{else if product.out_of_stock}}OutOfStock{{else if product.can_purchase '===' false}}OutOfStock{{else}}InStock{{/if}}">
-                <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition">
+                <!-- <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/{{product.condition}}Condition"> -->
+                <!-- Hard coding condition. Always selling products in new condition -->
+                <meta itemprop="itemCondition" itemtype="https://schema.org/OfferItemCondition" content="https://schema.org/NewCondition">
                 <meta itemprop="priceCurrency" content="{{currency_selector.active_currency_code}}">
                 <meta itemprop="url" content="{{product.url}}">
                 <div itemprop="priceSpecification" itemscope itemtype="https://schema.org/PriceSpecification">


### PR DESCRIPTION
1. Add itemprop="image" to responsive image. itemprop is required for Google schema to catch the main image
2. Add meta price itemprop to each price component (with tax, without tax). Google schema requires the price to be in this format. This may flag a warning on Schema.org validator, but doesn't interfere with how Schema.org gathers their schema data.
3. Hard code NewCondition to the content of the Condition schema. Polytek never sells used products, so hardcoding this ensures that the correct datatype is always sent.